### PR TITLE
fix: convert url to string in HTTPSignatureComponentResolver constructor

### DIFF
--- a/http_message_signatures/resolvers.py
+++ b/http_message_signatures/resolvers.py
@@ -26,7 +26,7 @@ class HTTPSignatureComponentResolver:
         self.message_type = "request"
         if hasattr(message, "status_code"):
             self.message_type = "response"
-        self.url = message.url
+        self.url = str(message.url)
         self.headers = CaseInsensitiveDict(message.headers)
 
     def resolve(self, component_node: http_sfv.Item):


### PR DESCRIPTION
- fix data type of url in HTTPSignatureComponentResolver 