### PR TITLE
Enforce has nonce

### DIFF
--- a/http_message_signatures/signatures.py
+++ b/http_message_signatures/signatures.py
@@ -222,6 +222,7 @@ class HTTPMessageVerifier(HTTPSignatureHandler):
             covered_components=sig_elements,
             parameters=dict(sig_params_node.params),
             body=None,
+            nonce=sig_input.params.get('nonce'),
         )
 
     def verify(

--- a/http_message_signatures/structures.py
+++ b/http_message_signatures/structures.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict, namedtuple
 from collections.abc import Mapping, MutableMapping
 
-VerifyResult = namedtuple("VerifyResult", "label algorithm covered_components parameters body")
+VerifyResult = namedtuple("VerifyResult", "label algorithm covered_components parameters body nonce")
 
 
 class CaseInsensitiveDict(MutableMapping):

--- a/test/test.py
+++ b/test/test.py
@@ -443,6 +443,14 @@ class TestHTTPMessageSignatures(unittest.TestCase):
         with self.assertRaisesRegex(InvalidSignature, 'Signature "created" parameter is set to a time in the future'):
             verifier.verify(self.test_request)
 
+    def test_has_nonce(self):
+        signer = HTTPMessageSigner(signature_algorithm=HMAC_SHA256, key_resolver=self.key_resolver)
+        nonce = 'random-nonce'
+        signer.sign(self.test_request, key_id="test-shared-secret", nonce=nonce)
+        verifier = HTTPMessageVerifier(signature_algorithm=HMAC_SHA256, key_resolver=self.key_resolver)
+        result = verifier.verify(self.test_request)
+        self.assertEqual(result[0].nonce, nonce)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -452,5 +452,13 @@ class TestHTTPMessageSignatures(unittest.TestCase):
         self.assertEqual(result[0].nonce, nonce)
 
 
+    def test_has_no_nonce(self):
+        signer = HTTPMessageSigner(signature_algorithm=HMAC_SHA256, key_resolver=self.key_resolver)
+        signer.sign(self.test_request, key_id="test-shared-secret", nonce=None)
+        verifier = HTTPMessageVerifier(signature_algorithm=HMAC_SHA256, key_resolver=self.key_resolver)
+        result = verifier.verify(self.test_request)
+        self.assertEqual(result[0].nonce, None)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### What

Return the nonce parameter from verify method (None is returned if it is not in the request).

### Why

Because this allows the verifier caller to:
- check that the client HAS provided a nonce (a bit like covered_components can be used to verify the the client has included the necessary fields in the signature)
- track the list of nonces used by the client to be able to detect nonce reuse in the caller.

### Alternative

I could also move the nonce reuse logic into the verifier and provide an enforce_has_nonce argument to the verify method but I decided against it because it would force the verifier to track long-running state (like the set of nonces used) or it would require the caller to give a handle to a function to check that a nonce has been used, both of which would increase the scope of the current API. Let me know if you prefer one of these options so I can rework the patch accordingly.  